### PR TITLE
feat: PR 작성자 자동 할당 워크플로우 추가

### DIFF
--- a/.github/workflows/pr-assignee.yml
+++ b/.github/workflows/pr-assignee.yml
@@ -1,0 +1,17 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add PR Assignees
+        uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
## 변경 사항

- PR 이 생성되거나 업데이트될 때 자동으로 PR 작성자를 담당자로 할당하는 GitHub Actions 워크플로우를 추가했습니다.

## 구현 내용

- **파일**: `.github/workflows/pr-assignee.yml`
- **트리거 조건**: PR이 열릴 때 (`opened`), PR이 동기화될 때 (`synchronize`)
- **동작**: PR 작성자(`${{ github.actor }}`)를 자동으로 담당자로 할당
