### PR TITLE
fix: 포크된 저장소에서 PR 자동 할당 방지 조건 추가

### DIFF
--- a/.github/workflows/pr-assignee.yml
+++ b/.github/workflows/pr-assignee.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+    # 포크된 저장소에서는 실행하지 않음
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
## 변경 사항

- 포크된 저장소에서 발생하는 403 에러를 방지하기 위해 원본 저장소에서만 실행되도록 조건을 추가했습니다.

## 구현 내용

- 포크된 저장소에서는 실행되지 않도록 `if: github.event.pull_request.head.repo.full_name == github.repository` 조건을 추가했습니다.
